### PR TITLE
A sasauth-mkhomedir.sh script isn't required for SAS Viya

### DIFF
--- a/playbooks/home-directory-creator/README.md
+++ b/playbooks/home-directory-creator/README.md
@@ -1,11 +1,11 @@
 # SAS Viya Administration Resource Kit (SAS Viya ARK) - Home Directory Creator Playbook
 
 ## Introduction
-This playbook enables the automatic creation of user home directories in SAS 9.x and SAS Viya environments. Home directories are required for users of multiple SAS Viya products, including SAS Studio and SAS Visual Data Mining and Machine Learning. They are also required for users of multiple SAS 9 applications.
+This playbook enables the automatic creation of user home directories in SAS 9.x environment. Home directories are required for users of multiple SAS 9 applications.
 
 It was inspired by [a blog post from Paul Homes](https://platformadmin.com/blogs/paul/2017/04/sas-user-linux-home-dir-auto-creation/). (Read the post for some background information).
 
-The Home Directory Creator playbook modifies various sasauth files so that they call a script that triggers the creation of a user's home directory. This method should work for both SAS 9.x and SAS Viya.
+The Home Directory Creator playbook modifies various sasauth files so that they call a script that triggers the creation of a user's home directory.
 
 ## Prerequisites for Running the Home Directory Creator Playbook
 Before running this playbook, take the following steps:
@@ -43,5 +43,4 @@ These specific tags run the code that performs the home directory configuration 
 * authfilemodif
 
 Copyright (c) 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
-SPDX-License-Identifier: Apache-2.0 
-
+SPDX-License-Identifier: Apache-2.0

--- a/playbooks/home-directory-creator/home-directory-creator.yml
+++ b/playbooks/home-directory-creator/home-directory-creator.yml
@@ -16,9 +16,6 @@
       - oddjob-mkhomedir
     mkhomedir_script: /etc/pam.d/sasauth-mkhomedir.sh
     sasauth_locations:
-      - /etc/pam.d/sasauth-spre
-      - /etc/pam.d/sasauth-viya
-      - /etc/pam.d/cas
       - /etc/pam.d/sasauth
 
   tasks:


### PR DESCRIPTION
A sasauth-mkhomedir.sh script isn't required for SAS Viya as we have SASMAKEHOMEDIR parameter described here:

https://go.documentation.sas.com/?cdcId=calcdc&cdcVersion=3.5&docsetId=dplyml0phy0lax&docsetTarget=p0npk8pk8rezusn0zss8b14tk8t0.htm&locale=en#n0wq5wobjqak86n1m04o6mgx8v5q

Also, it was recently discovered that sasauth-mkhomedir.sh is causing delays in the loading of SAS Studio V.