### PR TITLE
(#92) stop script updates to support RHEL8

### DIFF
--- a/playbooks/viya-mmsu/viya-services-stop.yml
+++ b/playbooks/viya-mmsu/viya-services-stop.yml
@@ -4,7 +4,7 @@
 #### Author: SAS Institute Inc.                                 ####
 ####################################################################
 #
-# Copyright (c) 2019-2021, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# Copyright (c) 2019-2022, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
@@ -262,7 +262,7 @@
         when: (stray_processes.stdout != '') and (enable_stray_cleanup|bool != true)
 
       - name: Clean up SAS stray processes if enabled
-        script: viya-svs.sh cleanps
+        script: viya-svs.sh cleanps "{{stray_processes.stdout_lines}}"
         when: (enable_stray_cleanup|bool == true) and (stray_processes.stdout != '')
         check_mode: no
         any_errors_fatal: true


### PR DESCRIPTION
Fixes #92: a customer reported an issue about launcher child processes is not stopped by viya-services-stop.yml".

After investigation, we found when issued command "systemctl stop sas-viya-xxx-default" behaved differently on RedHat7 vs. on RedHat8. 