### PR TITLE
Pre-install playbook check shell task failure (VIYAARK-301)

### DIFF
--- a/playbooks/pre-install-playbook/roles/viya-ark.preinstall/tasks/pre.shell_check.yml
+++ b/playbooks/pre-install-playbook/roles/viya-ark.preinstall/tasks/pre.shell_check.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2020, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# Copyright (c) 2019-2024, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
@@ -18,7 +18,7 @@
   - name: Ensure that the Bash shell is installed
     assert:
       that:
-        - ({{ current_shell.rc }} == 0)
+        - current_shell.rc == 0
       msg: |
         Bash does not appear to be installed on this system. 
         Viya requires that the default system shell is bash.


### PR DESCRIPTION
Regression testing found an issue related to our use jinja2 templating delimiters.
`[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: ({{ current_shell.rc }} == 0)
fatal: [deployTarget]: FAILED! => {"msg": "The conditional check '({{ current_shell.rc }} == 0)' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated."}`

