### PR TITLE
feat: new mmsu viya-services-enable playbook (VIYAARK-320)

### DIFF
--- a/playbooks/viya-mmsu/README.md
+++ b/playbooks/viya-mmsu/README.md
@@ -8,7 +8,7 @@ The SAS Viya Multi-Machine Services Utilities repository contains a set of playb
 
 * All services must have an Up status after the deployment has completed.
   See "Running the Playbooks" for instructions on listing the status of SAS Viya services.
-* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed. 
+* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed. The directory structure of this project must be preserved.
   For example: ```sas_viya_playbook/viya-ark/playbooks/viya-mmsu/```
 * Verify that the sas-viya-all-services script is exempted from system reboots. This step prevents the script from executing automatically when the machine is restarted. This can be done by running viya-services-disable.yml playbook.
 * sas-viya-all-services script should not be run manually on any machines when using MMSU playbooks.

--- a/playbooks/viya-mmsu/README.md
+++ b/playbooks/viya-mmsu/README.md
@@ -11,7 +11,7 @@ The SAS Viya Multi-Machine Services Utilities repository contains a set of playb
 * The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed.
   The directory structure of this project must be preserved.
   For example: ```sas_viya_playbook/viya-ark/playbooks/viya-mmsu/```
-* Verify that the sas-viya-all-services script is exempted from system reboots. This step prevents the script from executing automatically when the machine is restarted. This can be done by running viya-services-disable.yml playbook.
+* Verify that the sas-viya-all-services script is exempted from system reboots. See viya-services-disable.yml playbook.
 * sas-viya-all-services script should not be run manually on any machines when using MMSU playbooks.
 
 ## Supported deployment of MMSU Playbooks

--- a/playbooks/viya-mmsu/README.md
+++ b/playbooks/viya-mmsu/README.md
@@ -11,7 +11,7 @@ The SAS Viya Multi-Machine Services Utilities repository contains a set of playb
 * The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed.
   The directory structure of this project must be preserved.
   For example: ```sas_viya_playbook/viya-ark/playbooks/viya-mmsu/```
-* Verify that the sas-viya-all-services script is exempted from system reboots. See viya-services-disable.yml playbook.
+* Verify that the sas-viya-all-services script is exempted from system reboots.
 * sas-viya-all-services script should not be run manually on any machines when using MMSU playbooks.
 
 ## Supported deployment of MMSU Playbooks

--- a/playbooks/viya-mmsu/README.md
+++ b/playbooks/viya-mmsu/README.md
@@ -51,6 +51,14 @@ To start the minimally required set of services prior to starting a Restore, exe
 ```
 ansible-playbook viya-ark/playbooks/viya-mmsu/viya-services-restore.yml
 ```
+To disable sas-viya-all-services to run on system reboot, execute:
+```
+ansible-playbook viya-ark/playbooks/viya-mmsu/viya-services-disable.yml
+```
+To enable sas-viya-all-services to run on system reboot, execute:
+```
+ansible-playbook viya-ark/playbooks/viya-mmsu/viya-services-enable.yml
+```
 
 ## Notes about the viya-services-start-restore.yml Playbook
 The `viya-services-start-restore.yml` playbook is used to simplify some of the operations

--- a/playbooks/viya-mmsu/README.md
+++ b/playbooks/viya-mmsu/README.md
@@ -8,7 +8,8 @@ The SAS Viya Multi-Machine Services Utilities repository contains a set of playb
 
 * All services must have an Up status after the deployment has completed.
   See "Running the Playbooks" for instructions on listing the status of SAS Viya services.
-* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed. The directory structure of this project must be preserved.
+* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed. 
+  The directory structure of this project must be preserved.
   For example: ```sas_viya_playbook/viya-ark/playbooks/viya-mmsu/```
 * Verify that the sas-viya-all-services script is exempted from system reboots. This step prevents the script from executing automatically when the machine is restarted. This can be done by running viya-services-disable.yml playbook.
 * sas-viya-all-services script should not be run manually on any machines when using MMSU playbooks.

--- a/playbooks/viya-mmsu/README.md
+++ b/playbooks/viya-mmsu/README.md
@@ -8,7 +8,7 @@ The SAS Viya Multi-Machine Services Utilities repository contains a set of playb
 
 * All services must have an Up status after the deployment has completed.
   See "Running the Playbooks" for instructions on listing the status of SAS Viya services.
-* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed. 
+* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed.
   The directory structure of this project must be preserved.
   For example: ```sas_viya_playbook/viya-ark/playbooks/viya-mmsu/```
 * Verify that the sas-viya-all-services script is exempted from system reboots. This step prevents the script from executing automatically when the machine is restarted. This can be done by running viya-services-disable.yml playbook.

--- a/playbooks/viya-mmsu/README.md
+++ b/playbooks/viya-mmsu/README.md
@@ -8,10 +8,9 @@ The SAS Viya Multi-Machine Services Utilities repository contains a set of playb
 
 * All services must have an Up status after the deployment has completed.
   See "Running the Playbooks" for instructions on listing the status of SAS Viya services.
-* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed. This step prevents the script from executing automatically when the machine is restarted. This can be done by running viya-services-disable.yml playbook.
-  The directory structure of this project must be preserved.
+* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed. 
   For example: ```sas_viya_playbook/viya-ark/playbooks/viya-mmsu/```
-* Verify that the sas-viya-all-services script is exempted from system reboots.
+* Verify that the sas-viya-all-services script is exempted from system reboots. This step prevents the script from executing automatically when the machine is restarted. This can be done by running viya-services-disable.yml playbook.
 * sas-viya-all-services script should not be run manually on any machines when using MMSU playbooks.
 
 ## Supported deployment of MMSU Playbooks

--- a/playbooks/viya-mmsu/README.md
+++ b/playbooks/viya-mmsu/README.md
@@ -8,7 +8,7 @@ The SAS Viya Multi-Machine Services Utilities repository contains a set of playb
 
 * All services must have an Up status after the deployment has completed.
   See "Running the Playbooks" for instructions on listing the status of SAS Viya services.
-* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed.
+* The MMSU playbooks must be placed under the sas_viya_playbook directory where SAS Viya was deployed. This step prevents the script from executing automatically when the machine is restarted. This can be done by running viya-services-disable.yml playbook.
   The directory structure of this project must be preserved.
   For example: ```sas_viya_playbook/viya-ark/playbooks/viya-mmsu/```
 * Verify that the sas-viya-all-services script is exempted from system reboots.
@@ -30,10 +30,6 @@ The SAS Viya Multi-Machine Services Utilities repository contains a set of playb
 To list the status of all SAS Viya services and URLs, execute:
 ```
 ansible-playbook viya-ark/playbooks/viya-mmsu/viya-services-status.yml
-```
-To exempt sas-viya-all-services from system reboot, execute:
-```
-ansible-playbook viya-ark/playbooks/viya-mmsu/viya-services-disable.yml
 ```
 To stop all services gracefully, execute:
 ```

--- a/playbooks/viya-mmsu/viya-services-disable.yml
+++ b/playbooks/viya-mmsu/viya-services-disable.yml
@@ -19,7 +19,7 @@
   any_errors_fatal: true
 
   tasks:
-    - name: Disable SAS Viya all services from system reboot
+    - name: Disable SAS Viya all services at system reboot
       service:
         name: sas-viya-all-services
         enabled: no

--- a/playbooks/viya-mmsu/viya-services-enable.yml
+++ b/playbooks/viya-mmsu/viya-services-enable.yml
@@ -19,7 +19,7 @@
   any_errors_fatal: true
 
   tasks:
-    - name: Enable SAS Viya all services from system reboot
+    - name: Enable SAS Viya all services at system reboot
       service:
         name: sas-viya-all-services
         enabled: yes

--- a/playbooks/viya-mmsu/viya-services-enable.yml
+++ b/playbooks/viya-mmsu/viya-services-enable.yml
@@ -1,0 +1,25 @@
+####################################################################
+#### viya-services-enable.yml                                  ####
+####################################################################
+#### Author: SAS Institute Inc.                                 ####
+####################################################################
+#
+# Copyright (c) 2025, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+- import_playbook: ../common/handle_hostgroup_hyphens.yml
+  tags:
+    - always
+
+- hosts: sas_all
+  become: yes
+  become_user: root
+  gather_facts: False
+  any_errors_fatal: true
+
+  tasks:
+    - name: Enable SAS Viya all services from system reboot
+      service:
+        name: sas-viya-all-services
+        enabled: yes


### PR DESCRIPTION
This PR adds one new playbook to the viya-mmsu playbooks that will ensure `sas-viya-all-service` will start services on system reboot.  

This new playbook is offered as a means of reversing the actions taken by the existing `viya-services-disable.yml` playbook.  