### PR TITLE
fix: exclude unwanted services from mmsu restore start (VIYAARK-329)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce LF line endings for all shell script files
+*.sh text=auto eol=lf

--- a/playbooks/viya-mmsu/README.md
+++ b/playbooks/viya-mmsu/README.md
@@ -45,7 +45,7 @@ ansible-playbook viya-ark/playbooks/viya-mmsu/viya-services-restart.yml
 ```
 To start the minimally required set of services prior to starting a Restore, execute:
 ```
-ansible-playbook viya-ark/playbooks/viya-mmsu/viya-services-restore.yml
+ansible-playbook viya-ark/playbooks/viya-mmsu/viya-services-start-restore.yml
 ```
 To disable sas-viya-all-services to run on system reboot, execute:
 ```

--- a/playbooks/viya-mmsu/viya-services-start-prereq.yml
+++ b/playbooks/viya-mmsu/viya-services-start-prereq.yml
@@ -148,6 +148,7 @@
   tasks:
     - name: Start SAS multi-tenant services
       script: viya-svs.sh startmt
+      when: startmt|bool == true
 
 - hosts: CoreServices
   become: yes

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -13,6 +13,8 @@
       - always
 
   - import_playbook: viya-services-start-prereq.yml
+    vars:
+      startmt: false
     tags:
       - always
 

--- a/playbooks/viya-mmsu/viya-services-start.yml
+++ b/playbooks/viya-mmsu/viya-services-start.yml
@@ -13,6 +13,8 @@
     - always
 
 - import_playbook: viya-services-start-prereq.yml
+  vars:
+    startmt: true
   tags:
     - always
 


### PR DESCRIPTION
This PR prevents two unwanted services from being started during a viya3.x Restore setup.   Additionally, a README typo is fixed and a .gitattributes file is added to prevent ^M line endings from being manifest in certain cloning scenarios.