### PR TITLE
fix: start min services for restore (VIYAARK-330)

### DIFF
--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -57,6 +57,7 @@
           - name: Establish List of all SAS Services
             set_fact:
               filtered_sas_services: "{{ (filtered_sas_services + [item.value.name | replace ('.service', '')]) | unique }}"
+              quiet: true
             loop: "{{ ansible_facts.services | dict2items }}"
             when: item.value.name is defined and item.value.name.startswith('sas-viya-')
 

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -57,9 +57,9 @@
           - name: Establish List of all SAS Services
             set_fact:
               filtered_sas_services: "{{ (filtered_sas_services + [item.value.name | replace ('.service', '')]) | unique }}"
-              quiet: true
             loop: "{{ ansible_facts.services | dict2items }}"
             when: item.value.name is defined and item.value.name.startswith('sas-viya-')
+            no_log: true
 
           - name: Create Curated List of the Services to Start
             set_fact:

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -59,7 +59,6 @@
               filtered_sas_services: "{{ (filtered_sas_services + [item.value.name | replace ('.service', '')]) | unique }}"
             loop: "{{ ansible_facts.services | dict2items }}"
             when: item.value.name is defined and item.value.name.startswith('sas-viya-')
-            no_log: true
 
           - name: Create Curated List of the Services to Start
             set_fact:

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -77,5 +77,4 @@
               name: "{{ item }}"
               state: started
             with_items: "{{ intersected_services }}"
-            when: goforstart | default(false)
         when: not ansible_check_mode

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -12,6 +12,12 @@
     tags:
       - always
 
+  - import_playbook: viya-services-start-prereq.yml
+    vars:
+      startmt: false
+    tags:
+      - always
+
   - name: Minimal Services for Restore
     hosts: localhost
     gather_facts: false

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -43,6 +43,8 @@
     become_user: root
     gather_facts: false
     any_errors_fatal: true
+    vars:
+      global_restore_minimal_services: "{{ hostvars['localhost']['global_restore_minimal_services'] }}"
     tasks:
       - block:
           - name: Gather service facts

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -54,21 +54,17 @@
             set_fact:
               filtered_sas_services: []
 
-          - name: Establish List of SAS Services
+          - name: Establish List of all SAS Services
             set_fact:
               filtered_sas_services: "{{ (filtered_sas_services + [item.value.name | replace ('.service', '')]) | unique }}"
             loop: "{{ ansible_facts.services | dict2items }}"
             when: item.value.name is defined and item.value.name.startswith('sas-viya-')
 
-          - name: Display List of SAS Services per Host
-            debug:
-              msg: "Host {{ inventory_hostname  }} filtered SAS services: {{ filtered_sas_services }}"
-
-          - name: Create List of the Services to Start
+          - name: Create Curated List of the Services to Start
             set_fact:
               intersected_services: "{{ filtered_sas_services | intersect(global_restore_minimal_services) }}"
 
-          - name: Display List of Services to Start
+          - name: Display Curated List of Services to Start
             debug:
                 msg: "Host {{ inventory_hostname  }} services to start: {{ intersected_services }}"
 

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -50,11 +50,7 @@
           - name: Gather service facts
             service_facts:
 
-          - name: Display all gathered service facts
-            debug:
-              var: ansible_facts.services
-
-          - name: Initialize service list
+          - name: Initialize services list
             set_fact:
               filtered_sas_services: []
 
@@ -71,6 +67,10 @@
           - name: Create List of the Services to Start
             set_fact:
               intersected_services: "{{ filtered_sas_services | intersect(global_restore_minimal_services) }}"
+
+          - name: Display List of Services to Start
+            debug:
+                msg: "Host {{ inventory_hostname  }} services to start: {{ intersected_services }}"
 
           - name: Start SAS Services
             service:

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -42,6 +42,10 @@
           - name: Gather service facts
             service_facts:
 
+          - name: Display all gathered service facts
+            debug:
+              var: ansible_facts.services
+
           - name: Initialize service list
             set_fact:
               filtered_sas_services: []
@@ -61,4 +65,5 @@
               name: "{{ item }}"
               state: started
             with_items: "{{ filtered_sas_services }}"
+            when: goforstart | default(false)
         when: not ansible_check_mode

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -52,7 +52,7 @@
 
           - name: Establish List of SAS Services
             set_fact:
-              filtered_sas_services: "{{ filtered_sas_services + [item.value.name | replace ('.service', '')] }}"
+              filtered_sas_services: "{{ (filtered_sas_services + [item.value.name | replace ('.service', '')]) | unique }}"
             loop: "{{ ansible_facts.services | dict2items }}"
             when: item.value.name is defined and item.value.name.startswith('sas-viya-')
 

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -66,9 +66,9 @@
             debug:
               msg: "Host {{ inventory_hostname  }} filtered SAS services: {{ filtered_sas_services }}"
 
-          - name: Create List of Services to Start
+          - name: Create List of the Services to Start
             set_fact:
-            intersected_services: "{{ filtered_sas_services | intersect(global_restore_minimal_services) }}"
+              intersected_services: "{{ filtered_sas_services | intersect(global_restore_minimal_services) }}"
 
           - name: Start SAS Services
             service:

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -12,16 +12,53 @@
     tags:
       - always
 
-  - import_playbook: viya-services-start-prereq.yml
-    vars:
-      startmt: false
-    tags:
-      - always
-
-  - hosts: sas_all
-    become: yes
-    vars_files:
-      - viya-services-start-restore-vars.yml
+  - name: Minimal Services for Restore
+    hosts: localhost
+    gather_facts: false
     tasks:
-      - name: Starting minimal services before a Restore operation
-        script: viya-svs.sh start "{{ restore_minimal_services | join(' ') }}"
+      - name: Load Minimal Services for Restore from vars file
+        include_vars:
+          file: viya-services-start-restore-vars.yml
+        delegate_to: localhost
+
+      - name: Minimal Services that must be started for Restore
+        debug:
+          var: restore_minimal_services
+        delegate_to: localhost
+
+      - name: Set restore_minimal_services globally
+        set_fact:
+          global_restore_minimal_services: "{{ restore_minimal_services }}"
+        delegate_to: localhost
+
+  - name: Determine where SAS services reside and start the services
+    hosts: sas_all
+    become: yes
+    become_user: root
+    gather_facts: false
+    any_errors_fatal: true
+    tasks:
+      - block:
+          - name: Gather service facts
+            service_facts:
+
+          - name: Initialize service list
+            set_fact:
+              filtered_sas_services: []
+
+          - name: Establish List of SAS Services
+            set_fact:
+              filtered_sas_services: "{{ filtered_sas_services + [item.value.name | replace ('.service', '')] }}"
+            loop: "{{ ansible_facts.services | dict2items }}"
+            when: item.value.name is defined and item.value.name.startswith('sas-viya-')
+
+          - name: Display List of SAS Services per Host
+            debug:
+              msg: "Host {{ inventory_hostname  }} filtered SAS services: {{ filtered_sas_services }}"
+
+          - name: Start SAS Services
+            service:
+              name: "{{ item }}"
+              state: started
+            with_items: "{{ filtered_sas_services }}"
+        when: not ansible_check_mode

--- a/playbooks/viya-mmsu/viya-services-start-restore.yml
+++ b/playbooks/viya-mmsu/viya-services-start-restore.yml
@@ -66,10 +66,14 @@
             debug:
               msg: "Host {{ inventory_hostname  }} filtered SAS services: {{ filtered_sas_services }}"
 
+          - name: Create List of Services to Start
+            set_fact:
+            intersected_services: "{{ filtered_sas_services | intersect(global_restore_minimal_services) }}"
+
           - name: Start SAS Services
             service:
               name: "{{ item }}"
               state: started
-            with_items: "{{ filtered_sas_services }}"
+            with_items: "{{ intersected_services }}"
             when: goforstart | default(false)
         when: not ansible_check_mode


### PR DESCRIPTION
This PR addresses failures of the new `viya-services-start-restore.yml` in a multi-machine viya3 deployment.  The refactoring of the playbook now has the logical flow of:

1. After the prerequisite set of services that always must be started are started (existing behavior), the minimal services for the Restore part of a Backup & Restore scenario are gathered. (static list: `viya-services-start-restore-vars.yml`)
2. Lists of all services, based on their allocation across the various hosts in the deployment, are gathered.
3. The intersection of the minimal services required for Restore process and the set of all services allocated to each machine is established.  These curated lists of services are the ones we need to start beyond the prereq services.
4. Loop through those curated lists of services (per host) and start the services.
